### PR TITLE
Use "first-given" approach to handle duplicate parameters key

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,33 @@ try {
 }
 ```
 
+## Implementation notes
+
+The [RFC 2397][rfc2397-url] is unfortunately vague regarding many details of the
+syntax of the data URL scheme. This node module does its best to have a solid
+implementation of the specification of the original RFC. However, some
+independent choices had to be made where the specification is unclear.
+
+### Duplicate parameter attribute handling
+
+The [RFC 2397][rfc2397-url] does not specify what needs to be done when
+duplicate parameter keys are encountered. The approach retained by this
+implementation is **first given**.
+
+Example:
+
+```javascript
+var moddataurl = require("node-rfc2397");
+var info = moddataurl.parseSync("data:text/plain;foo=bar;foo=nope,");
+console.log(info);
+// {
+//     mime: 'text/plain',
+//     parameters: { foo: 'bar' },
+//     data: <Buffer >,
+// }
+
+```
+
 ## Tests
 
 To run the test suite, first install the dependencies, then run `npm test`:

--- a/index.js
+++ b/index.js
@@ -123,9 +123,8 @@ module.exports = {
             */
             var attribute = pct_decode(splitted[0]).toString();
             var value     = pct_decode(splitted[1]).toString();
-            if (attribute in parameters)
-                throw new Error("duplicate parameter key: " + attribute);
-            parameters[attribute] = value;
+            if (!(attribute in parameters))
+                parameters[attribute] = value;
             return parameters;
         }, {});
 

--- a/test/index.js
+++ b/test/index.js
@@ -147,9 +147,13 @@ describe("node-rfc2397", function () {
             });
             context("when given duplicate parameter keys", function () {
                 it("should throw a duplicate parameter keys error", function () {
-                    expect(function () {
-                        moddataurl.parseSync("data:text/plain;foo=bar;foo=nope,");
-                    }).to.throw(Error, "duplicate parameter key: foo");
+                    expect(moddataurl.parseSync("data:text/plain;foo=bar;foo=nope,")).to.deep.equal({
+                        mime: "text/plain",
+                        parameters: {
+                            foo: "bar",
+                        },
+                        data: Buffer.from([])
+                    });
                 });
             });
             context("when given an URL encoded value parameter", function () {


### PR DESCRIPTION
RFC 2397 does not tell how to handle the duplicate parameter attribute (key) issue. It seems that the **first-given** approach is the most widespread among web browsers although I am unable to find references to this (I used to).
